### PR TITLE
Add the all-contributors specification to brahma

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -18,6 +18,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "kajal-jotwani",
+      "name": "Kajal Jotwani",
+      "avatar_url": "https://avatars.githubusercontent.com/u/130732790?v=4",
+      "profile": "https://kajal-jotwani-portfolio.vercel.app/",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -23,7 +23,7 @@
       "login": "kajal-jotwani",
       "name": "Kajal Jotwani",
       "avatar_url": "https://avatars.githubusercontent.com/u/130732790?v=4",
-      "profile": "https://kajal-jotwani-portfolio.vercel.app/",
+      "profile": "https://github.com/kajal-jotwani",
       "contributions": [
         "code"
       ]

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,25 @@
+{
+  "projectName": "brahma",
+  "projectOwner": "smrghsh",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": true,
+  "commitConvention": "none",
+  "contributors": [
+    {
+      "login": "smrghsh",
+      "name": "Samir Ghosh",
+      "avatar_url": "https://avatars.githubusercontent.com/u/22751315?v=4",
+      "profile": "https://github.com/smrghsh",
+      "contributions": [
+        "code"
+      ]
+    }
+  ],
+  "contributorsPerLine": 7,
+  "linkToUsage": true
+}

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Using this library necessitates strong development practices in Three.js and som
 It's the early stages of this project, so feel free to reach out to contributors and ask about the project.
 
 ## Contributors
-
+<!-- I will contribute here -->
 <!-- https://github.com/all-contributors/all-contributors -->
 
 ## Support

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ It's the early stages of this project, so feel free to reach out to contributors
   <tbody>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/smrghsh"><img src="https://avatars.githubusercontent.com/u/22751315?v=4?s=100" width="100px;" alt="Samir Ghosh"/><br /><sub><b>Samir Ghosh</b></sub></a><br /><a href="https://github.com/smrghsh/brahma/commits?author=smrghsh" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://kajal-jotwani-portfolio.vercel.app/"><img src="https://avatars.githubusercontent.com/u/130732790?v=4?s=100" width="100px;" alt="Kajal Jotwani"/><br /><sub><b>Kajal Jotwani</b></sub></a><br /><a href="https://github.com/smrghsh/brahma/commits?author=kajal-jotwani" title="Code">💻</a></td>
     </tr>
   </tbody>
   <tfoot>

--- a/README.md
+++ b/README.md
@@ -35,6 +35,30 @@ It's the early stages of this project, so feel free to reach out to contributors
 ## Contributors
 <!-- I will contribute here -->
 <!-- https://github.com/all-contributors/all-contributors -->
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/smrghsh"><img src="https://avatars.githubusercontent.com/u/22751315?v=4?s=100" width="100px;" alt="Samir Ghosh"/><br /><sub><b>Samir Ghosh</b></sub></a><br /><a href="https://github.com/smrghsh/brahma/commits?author=smrghsh" title="Code">💻</a></td>
+    </tr>
+  </tbody>
+  <tfoot>
+    <tr>
+      <td align="center" size="13px" colspan="7">
+        <img src="https://raw.githubusercontent.com/all-contributors/all-contributors-cli/1b8533af435da9854653492b1327a23a4dbd0a10/assets/logo-small.svg">
+          <a href="https://all-contributors.js.org/docs/en/bot/usage">Add your contributions</a>
+        </img>
+      </td>
+    </tr>
+  </tfoot>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->
 
 ## Support
 Support for the came in many ways from

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ It is purposely design to require minimal computation, and can work across every
 
 
 ## Examples
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
 
 
 ## Features
@@ -33,8 +34,10 @@ Using this library necessitates strong development practices in Three.js and som
 It's the early stages of this project, so feel free to reach out to contributors and ask about the project.
 
 ## Contributors
-<!-- I will contribute here -->
 <!-- https://github.com/all-contributors/all-contributors -->
+
+Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->
@@ -42,7 +45,7 @@ It's the early stages of this project, so feel free to reach out to contributors
   <tbody>
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/smrghsh"><img src="https://avatars.githubusercontent.com/u/22751315?v=4?s=100" width="100px;" alt="Samir Ghosh"/><br /><sub><b>Samir Ghosh</b></sub></a><br /><a href="https://github.com/smrghsh/brahma/commits?author=smrghsh" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://kajal-jotwani-portfolio.vercel.app/"><img src="https://avatars.githubusercontent.com/u/130732790?v=4?s=100" width="100px;" alt="Kajal Jotwani"/><br /><sub><b>Kajal Jotwani</b></sub></a><br /><a href="https://github.com/smrghsh/brahma/commits?author=kajal-jotwani" title="Code">💻</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/kajal-jotwani"><img src="https://avatars.githubusercontent.com/u/130732790?v=4?s=100" width="100px;" alt="Kajal Jotwani"/><br /><sub><b>Kajal Jotwani</b></sub></a><br /><a href="https://github.com/smrghsh/brahma/commits?author=kajal-jotwani" title="Code">💻</a></td>
     </tr>
   </tbody>
   <tfoot>
@@ -60,6 +63,8 @@ It's the early stages of this project, so feel free to reach out to contributors
 <!-- prettier-ignore-end -->
 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
+
+This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
 
 ## Support
 Support for the came in many ways from

--- a/package.json
+++ b/package.json
@@ -31,9 +31,18 @@
   "license": "MIT",
   "devDependencies": {
     "all-contributors-cli": "^6.26.1",
-    "three": "^0.177.0"
+    "@babel/core": "^7.27.4",
+    "@babel/preset-env": "^7.27.2",
+    "@rollup/plugin-babel": "^6.0.4",
+    "@rollup/plugin-commonjs": "^28.0.5",
+    "@rollup/plugin-node-resolve": "^16.0.1",
+    "@rollup/plugin-terser": "^0.4.4",
+    "rollup": "^4.43.0"
   },
   "peerDependencies": {
+    "three": "^0.177.0"
+  },
+  "devDependencies": {
     "three": "^0.177.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,18 +30,10 @@
   "author": "Samir Ghosh",
   "license": "MIT",
   "devDependencies": {
-    "@babel/core": "^7.27.4",
-    "@babel/preset-env": "^7.27.2",
-    "@rollup/plugin-babel": "^6.0.4",
-    "@rollup/plugin-commonjs": "^28.0.5",
-    "@rollup/plugin-node-resolve": "^16.0.1",
-    "@rollup/plugin-terser": "^0.4.4",
-    "rollup": "^4.43.0"
-  },
-  "peerDependencies": {
+    "all-contributors-cli": "^6.26.1",
     "three": "^0.177.0"
   },
-  "devDependencies": {
+  "peerDependencies": {
     "three": "^0.177.0"
   }
 }


### PR DESCRIPTION
The [all-contributors](https://github.com/all-contributors/all-contributors) specification allows many contributors to get credit for working on the repository. 

I will add the specification to the README.md file and invite prior contributors to contribute.

- Added `.all-contributorsrc` configuration file to manage contributor data using the All Contributors CLI.
- Updated `README.md` with contributor table and badge following the All Contributors specification.
- Included initial contributors.

![image](https://github.com/user-attachments/assets/29d227fb-5455-4acd-8651-4833f9a5f72f)
